### PR TITLE
Fixed Out of source build for example plugins.

### DIFF
--- a/src/plugins/example-cache/Makefile.am
+++ b/src/plugins/example-cache/Makefile.am
@@ -17,4 +17,5 @@ libdcplugin_example_cache_la_LDFLAGS = \
 
 libdcplugin_example_cache_la_CPPFLAGS = \
 	$(LTDLINCL) \
-	-I../../include
+	-I../../include \
+	-I$(srcdir)/../../include

--- a/src/plugins/example-ldns-aaaa-blocking/Makefile.am
+++ b/src/plugins/example-ldns-aaaa-blocking/Makefile.am
@@ -18,4 +18,5 @@ libdcplugin_example_ldns_aaaa_blocking_la_LDFLAGS = \
 
 libdcplugin_example_ldns_aaaa_blocking_la_CPPFLAGS = \
 	$(LTDLINCL) \
-	-I../../include
+	-I../../include \
+	-I$(srcdir)/../../include

--- a/src/plugins/example-ldns-blocking/Makefile.am
+++ b/src/plugins/example-ldns-blocking/Makefile.am
@@ -18,4 +18,5 @@ libdcplugin_example_ldns_blocking_la_LDFLAGS = \
 
 libdcplugin_example_ldns_blocking_la_CPPFLAGS = \
 	$(LTDLINCL) \
-	-I../../include
+	-I../../include \
+	-I$(srcdir)/../../include

--- a/src/plugins/example-ldns-forwarding/Makefile.am
+++ b/src/plugins/example-ldns-forwarding/Makefile.am
@@ -18,4 +18,5 @@ libdcplugin_example_ldns_forwarding_la_LDFLAGS = \
 
 libdcplugin_example_ldns_forwarding_la_CPPFLAGS = \
 	$(LTDLINCL) \
-	-I../../include
+	-I../../include \
+	-I$(srcdir)/../../include

--- a/src/plugins/example-logging/Makefile.am
+++ b/src/plugins/example-logging/Makefile.am
@@ -16,4 +16,5 @@ libdcplugin_example_logging_la_LDFLAGS = \
 
 libdcplugin_example_logging_la_CPPFLAGS = \
 	$(LTDLINCL) \
-	-I../../include
+	-I../../include \
+	-I$(srcdir)/../../include

--- a/src/plugins/example/Makefile.am
+++ b/src/plugins/example/Makefile.am
@@ -16,4 +16,5 @@ libdcplugin_example_la_LDFLAGS = \
 
 libdcplugin_example_la_CPPFLAGS = \
 	$(LTDLINCL) \
-	-I../../include
+	-I../../include \
+	-I$(srcdir)/../../include

--- a/src/plugins/vendor-specific/example-ldns-opendns-deviceid/Makefile.am
+++ b/src/plugins/vendor-specific/example-ldns-opendns-deviceid/Makefile.am
@@ -21,4 +21,5 @@ libdcplugin_example_ldns_opendns_deviceid_la_LDFLAGS = \
 
 libdcplugin_example_ldns_opendns_deviceid_la_CPPFLAGS = \
 	$(LTDLINCL) \
-	-I../../../include
+	-I../../../include \
+	-I$(srcdir)/../../../include

--- a/src/plugins/vendor-specific/example-ldns-opendns-set-client-ip/Makefile.am
+++ b/src/plugins/vendor-specific/example-ldns-opendns-set-client-ip/Makefile.am
@@ -21,4 +21,5 @@ libdcplugin_example_ldns_opendns_set_client_ip_la_LDFLAGS = \
 
 libdcplugin_example_ldns_opendns_set_client_ip_la_CPPFLAGS = \
 	$(LTDLINCL) \
-	-I../../../include
+	-I../../../include \
+	-I$(srcdir)/../../../include


### PR DESCRIPTION
More issues:
I am still using the C implementation of dnscrypt-proxy on OpenWrt.
According to the libevent Changelog in `src/libevent-modified/ChangeLog` it might be possible that this version is vulnerable to [CVE-2016-10197](https://www.cvedetails.com/cve/CVE-2016-10197/), [CVE-2016-10196](https://www.cvedetails.com/cve/CVE-2016-10196/) and [CVE-2016-10195](https://www.cvedetails.com/cve/CVE-2016-10195/). Need to investigate.

Signed-off-by: Toni Uhlig <matzeton@googlemail.com>